### PR TITLE
Handle symlinks

### DIFF
--- a/src/rmrdir.php
+++ b/src/rmrdir.php
@@ -11,7 +11,7 @@ function rmrdir($dir) {
     $it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
     foreach($it as $file) {
         if ('.' === $file->getBasename() || '..' ===  $file->getBasename()) continue;
-        if ($file->isDir()) rmdir($file->getPathname());
+	if ($file->isDir() && ! $file->isLink()) rmdir($file->getPathname());
         else unlink($file->getPathname());
     }
     return rmdir($dir);


### PR DESCRIPTION
Otherwise if a symlink to a directory is encountered in the tree, it tries to rmdir the symlink inode, which fails with a warning, and then the later attempt to rmdir the directory with the symlink still in it also fails.